### PR TITLE
all or nothing sync

### DIFF
--- a/apps/local/lib/sync/runSync.ts
+++ b/apps/local/lib/sync/runSync.ts
@@ -136,11 +136,11 @@ function storageUrlToKey(url: string, bucket: string): string {
   return url.slice(idx + marker.length);
 }
 
-async function downloadFiles(db: DB, files: FileRow[], lessons: Lesson[]) {
-  const updateStmt = db.prepare(
-    "UPDATE files SET mime_type = ?, local_path = ? WHERE id = ?",
-  );
-
+async function downloadFiles(
+  files: FileRow[],
+  lessons: Lesson[],
+  stagingDir: string,
+) {
   const lessonMap = new Map<number, string>();
   for (const lesson of lessons) {
     lessonMap.set(lesson.id, lesson.name);
@@ -168,32 +168,21 @@ async function downloadFiles(db: DB, files: FileRow[], lessons: Lesson[]) {
 
     const response = await fetch(file.storage_path);
     if (!response.ok || !response.body) {
-      console.warn(
-        "Could not stream download",
-        file.storage_path,
-        response.status,
-      );
-      continue;
+      throw new Error(`Download failed for ${file.storage_path}`);
     }
 
-    const localPath = path.join(LOCAL_DIR, objectKey);
-    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    const stagedPath = path.join(stagingDir, objectKey);
+    fs.mkdirSync(path.dirname(stagedPath), { recursive: true });
 
     try {
       const webStream =
         response.body as unknown as NodeReadableStream<Uint8Array>;
       const nodeReadable = Readable.fromWeb(webStream);
 
-      await pipeline(nodeReadable, fs.createWriteStream(localPath));
+      await pipeline(nodeReadable, fs.createWriteStream(stagedPath)); // write to Stage Directory
     } catch (err) {
-      console.warn("Error streaming file to disk", file.storage_path, err);
-      continue;
+      throw new Error(`Streaming failed for ${file.storage_path}, ${err}`);
     }
-
-    const inferredMime =
-      mime.lookup(file.name || localPath) || "application/octet-stream";
-
-    updateStmt.run(inferredMime, localPath, file.id);
   }
 }
 
@@ -213,8 +202,11 @@ export async function runSync() {
 
   isSyncRunning = true;
 
+  let stagingDir: string | null = null;
+
   try {
     fs.mkdirSync(LOCAL_DIR, { recursive: true });
+    stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), "rose-sync-")); // Temp Directory for staging
 
     const DB_PATH = path.join(process.cwd(), "rose-academies-uganda.db");
 
@@ -223,8 +215,30 @@ export async function runSync() {
     try {
       createSchema(db);
       const { groups, lessons, files } = await fetchFromSupabase();
+      await downloadFiles(files, lessons, stagingDir); // pass in staging directory
       insertIntoSQLite(db, groups, lessons, files);
-      await downloadFiles(db, files, lessons);
+      const updateStmt = db.prepare(
+        "UPDATE files SET mime_type = ?, local_path = ? WHERE id = ?",
+      );
+      for (const file of files) {
+        if (!file.storage_path) continue;
+
+        const objectKey = storageUrlToKey(file.storage_path, BUCKET);
+        const stagedPath = path.join(stagingDir, objectKey);
+        const finalPath = path.join(LOCAL_DIR, objectKey);
+
+        if (fs.existsSync(stagedPath)) {
+          // If stagePath exists, we can now write everything to the final path, in one go
+          fs.mkdirSync(path.dirname(finalPath), { recursive: true });
+          fs.renameSync(stagedPath, finalPath);
+
+          const inferredMime =
+            mime.lookup(file.name || finalPath) || "application/octet-stream";
+
+          updateStmt.run(inferredMime, finalPath, file.id);
+        }
+      }
+      fs.rmSync(stagingDir, { recursive: true, force: true }); // Cleanup: Remove staging directory
     } finally {
       db.close();
     }
@@ -235,6 +249,10 @@ export async function runSync() {
     };
   } catch (error) {
     console.error("Sync failed:", error);
+
+    if (stagingDir) {
+      fs.rmSync(stagingDir, { recursive: true, force: true }); // remove staging directory and files if sync fails
+    }
 
     return {
       ok: false,


### PR DESCRIPTION
[//]: # "add the issue number from your sprint in the space below"
closes #58 

### description / changes made 
[//]: # "list (in bullet points) the main changes of this PR, especially if it's something that wasn't mentioned in the original issue."
- Implemented atomic syncing for lesson files using a staging directory.
- Files are first downloaded into a temporary staging folder instead of the final storage location.
- If any file fails to download, the sync aborts and the staging folder is deleted.
- The failing file’s `storage_path` is included in the error message to identify which file caused the failure.
- Only after all downloads succeed do we:
  - Insert metadata into SQLite
  - Move staged files into the final local directory
  - Update `mime_type` and `local_path` fields in the database.
- Ensures that partial downloads do not affect the final filesystem state.

### screenshots / demo vids
[//]: # "show evidence that your PR works -- especially important if this PR changed the UI."

I JUST REALIZED THAT IT ONLY RECORDED GOOGLE CHROME INSTEAD OF MY WHOLE SCREEN AND I DONT WANT TO RECORD THE WHOLE DEMO AGAIN BUT I WILL WALK YOU THROUGH EACH VIDEO

In this vid, im just simply testing that the sync process still works and that my code didnt mess anything up (ignore the duplicate lesson), but once i synced, you could see the lesson in the local app

https://github.com/user-attachments/assets/0b2971ac-44d6-4d89-9164-0cda10f5ca60


This vid demo is more complex, I start by adding two new lessons, one with a good file, one with a bad file. For all or nothing sync, even though one lesson is good and has a good file, the other one has  a bad (corrupt) file, meaning that we sync NOTHING since there is a corrupt file. This makes it more consistent and stable! To emulate corruption in a file, I set the file storage path as https://httpbin.org/status/404, which makes it fail. There is a long awkward part in the video where nothing is happening, that is because I am showing and displaying VS Code, which wasn't in my recording. Anyways it fails and if you look at the image below you can see the error being thrown and how it displays which storage path is causing the error. In addition, the local app never gets synced and doesnt include the good file (which is what we want) as the corrupt file prevented it from being synced.

https://github.com/user-attachments/assets/9e22c034-a53f-4dca-aa3f-76fa2f131248



<img width="633" height="267" alt="image" src="https://github.com/user-attachments/assets/3c77dec8-5895-45ae-bc63-7739c9c6ab44" />



### next steps
[//]: # "is there anything in this PR that does NOT work yet or needs to be refined later? are there any temporary fixes or files that need to be cleaned up later? did this PR involve any implementation decisions that will affect future PRs?"

If syncing doesn't work in the local app (like it fails), then every 30 seconds it will attempt to sync again (then fail again), and again, looping forever until the error eventually gets fixed. Do we want it like that? Im assuming probably not, which is something we will have to work on.

### notes
[//]: # "is there anything else that the reviewer of this PR should know? is there anything you'd like feedback on?"

I dont know if this was already tested but the local app cannot sync until it compiles, so @nehaahussain was right, (like she always is). I looked into it a bit and apparently if we put it in one of the backend files instead of a frontend file, i believe it should start the auto syncing as soon as we boot up the pi. Just wanted to let you know 👯 

CC: @nathandtam
