### PR TITLE
add hashes to files to detect duplicates

### DIFF
--- a/apps/cloud/api/supabase/files.ts
+++ b/apps/cloud/api/supabase/files.ts
@@ -1,22 +1,30 @@
 import type { LocalFile } from "@/types/schema";
 import { getSupabaseBrowserClient } from "./browser";
 
+async function hashFile(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
+}
+
 export async function uploadFile(
   lessonId: number,
   file: File,
 ): Promise<LocalFile> {
   const supabase = getSupabaseBrowserClient();
 
-  // check if file already exists
+  const hash = await hashFile(file);
+
+  // check if a file with this hash already exists
   const { data: existingFile } = await supabase
     .from("Files")
     .select("*")
-    .eq("name", file.name)
-    .eq("size_bytes", file.size)
+    .eq("hash", hash)
     .maybeSingle();
 
   if (existingFile) {
-    // just link the lesson to the file
+    // reuse the existing file — just link the lesson to it
     const { error } = await supabase.from("LessonFiles").insert({
       lesson_id: lessonId,
       file_id: existingFile.id,
@@ -27,7 +35,7 @@ export async function uploadFile(
     return existingFile as LocalFile;
   }
 
-  // upload new file
+  // truly new file — upload to storage
   const objectPath = `teacher-1/${file.name}`;
 
   const { error: storageError } = await supabase.storage
@@ -41,20 +49,21 @@ export async function uploadFile(
   const publicUrl = pub?.publicUrl;
   if (!publicUrl) throw new Error("Failed to compute public URL");
 
-  // create file row
+  // create Files row with hash
   const { data: fileRow, error: fileError } = await supabase
     .from("Files")
     .insert({
       name: file.name,
       size_bytes: file.size,
       storage_path: publicUrl,
+      hash,
     })
     .select()
     .single();
 
   if (fileError) throw fileError;
 
-  // link lesson + file
+  // link lesson to file
   const { error: joinError } = await supabase.from("LessonFiles").insert({
     lesson_id: lessonId,
     file_id: fileRow.id,

--- a/apps/cloud/types/schema.d.ts
+++ b/apps/cloud/types/schema.d.ts
@@ -67,5 +67,6 @@ export type LocalFile = {
   name: string;
   size_bytes: number;
   storage_path: string;
+  hash: string;
   lesson_id: number | null;
 };


### PR DESCRIPTION
[//]: # "add the issue number from your sprint in the space below"
closes #74 

### description / changes made 
[//]: # "list (in bullet points) the main changes of this PR, especially if it's something that wasn't mentioned in the original issue."
- added a hash field to files uploaded
- duplicate files are now checked using the hash, and since a hash uniquely identifies a file, duplicate files only appear once in files table.
- lessons table will still populate lesson <> file no, but now multiple lessons can share a file no

### screenshots / demo vids
<img width="730" height="76" alt="proofofduplicate" src="https://github.com/user-attachments/assets/705d4bcd-f933-4b10-bce0-e30139481f94" />
<img width="1142" height="632" alt="ASUDHASDHKJh" src="https://github.com/user-attachments/assets/d7fbf72a-bd4d-423b-af74-0c68df2633a9" />
fuck my big arrow covered the horse jpg id number but trust me its 80



### next steps
[//]: # "is there anything in this PR that does NOT work yet or needs to be refined later? are there any temporary fixes or files that need to be cleaned up later? did this PR involve any implementation decisions that will affect future PRs?"

### notes
[//]: # "is there anything else that the reviewer of this PR should know? is there anything you'd like feedback on?"

CC: @nathandtam
