### PR TITLE
prevent lessons from being placed into offline library if there are no files inside

### DIFF
--- a/apps/cloud/app/(authed)/app/lessons/[lessonId]/LessonDetailClient.tsx
+++ b/apps/cloud/app/(authed)/app/lessons/[lessonId]/LessonDetailClient.tsx
@@ -49,6 +49,7 @@ export default function LessonDetailClient({
           lessonId={lesson.id}
           isOffline={isOffline}
           setIsOffline={setIsOffline}
+          hasFiles={files.length > 0}
         />
 
         <EditLessonButton lesson={lesson} />

--- a/apps/cloud/components/OfflineToggle/index.tsx
+++ b/apps/cloud/components/OfflineToggle/index.tsx
@@ -43,6 +43,10 @@ function OfflineToggle({
 
         setIsOffline(false);
       } else {
+        if (!hasFiles) {
+          console.error("Cannot send lesson to offline without files.");
+          return;
+        }
         const { error } = await supabase.from("DeviceLessons").insert({
           device_id: deviceId,
           lesson_id: lessonId,

--- a/apps/cloud/components/OfflineToggle/index.tsx
+++ b/apps/cloud/components/OfflineToggle/index.tsx
@@ -9,16 +9,18 @@ function OfflineToggle({
   lessonId,
   isOffline,
   setIsOffline,
+  hasFiles,
 }: {
   deviceId: string | null;
   lessonId: number;
   isOffline: boolean;
   setIsOffline: (isOffline: boolean) => void;
+  hasFiles: boolean;
 }) {
   const [isUpdating, setIsUpdating] = useState(false);
 
   const handleToggle = async () => {
-    if (isUpdating || !deviceId || Number.isNaN(lessonId)) {
+    if (isUpdating || !deviceId || Number.isNaN(lessonId) || !hasFiles) {
       return;
     }
 
@@ -74,7 +76,7 @@ function OfflineToggle({
   return (
     <SyncButton
       onClick={handleToggle}
-      disabled={isUpdating || !deviceId || Number.isNaN(lessonId)}
+      disabled={isUpdating || !deviceId || Number.isNaN(lessonId) || !hasFiles}
     >
       {syncLabel[syncButtonKey]}
     </SyncButton>

--- a/apps/cloud/components/modals/CreateLessonModal/CreateLessonModal.tsx
+++ b/apps/cloud/components/modals/CreateLessonModal/CreateLessonModal.tsx
@@ -239,6 +239,11 @@ export default function CreateLessonModal({ isOpen, onClose }: Props) {
       }
 
       if (sendToOffline) {
+        if (snapshot.length === 0) {
+          throw new Error(
+            "Cannot send lesson to offline library without files.",
+          );
+        }
         const { error: deviceLessonError } = await supabase
           .from("DeviceLessons")
           .upsert(

--- a/apps/cloud/components/modals/CreateLessonModal/CreateLessonModal.tsx
+++ b/apps/cloud/components/modals/CreateLessonModal/CreateLessonModal.tsx
@@ -89,6 +89,13 @@ export default function CreateLessonModal({ isOpen, onClose }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const data = useContext(DataContext);
   const supabase = getSupabaseBrowserClient();
+  const hasFiles = files.length > 0;
+
+  useEffect(() => {
+    if (!hasFiles && sendToOffline) {
+      setSendToOffline(false);
+    }
+  }, [hasFiles, sendToOffline]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -530,8 +537,15 @@ export default function CreateLessonModal({ isOpen, onClose }: Props) {
               id="offline-toggle"
               checked={sendToOffline}
               onChange={e => setSendToOffline(e.target.checked)}
+              disabled={!hasFiles}
             />
-            <ToggleTrack htmlFor="offline-toggle" $checked={sendToOffline}>
+            <ToggleTrack
+              htmlFor="offline-toggle"
+              $checked={sendToOffline}
+              style={{
+                pointerEvents: hasFiles ? "auto" : "none",
+              }}
+            >
               <ToggleThumb $checked={sendToOffline} />
             </ToggleTrack>
           </ToggleWrapper>


### PR DESCRIPTION
[//]: # "add the issue number from your sprint in the space below"
closes #150 

### description / changes made 
[//]: # "list (in bullet points) the main changes of this PR, especially if it's something that wasn't mentioned in the original issue."
- disables toggle in create lesson modal when no files have been added
- disables send to sync button on lesson page if no files exist
- validate that the lesson has at least one file when we create a DeviceLessons row

### screenshots / demo vids
[//]: # "show evidence that your PR works -- especially important if this PR changed the UI."

https://github.com/user-attachments/assets/fb91632c-a51f-434a-a02d-e755c298257e

### next steps
[//]: # "is there anything in this PR that does NOT work yet or needs to be refined later? are there any temporary fixes or files that need to be cleaned up later? did this PR involve any implementation decisions that will affect future PRs?"
- the send to offline logic is in 2 different places and should ideally be in 1 file since they do the same thing -> we should clean up `apps/cloud/components/OfflineToggle/index.tsx` 
- we may want to change the UI when the toggle/button is disabled so the users know exactly why they are disabled
- users should be able to click out of the select a village dropdown when we click anywhere on the outside modal

### notes
[//]: # "is there anything else that the reviewer of this PR should know? is there anything you'd like feedback on?"

CC: @nathandtam
