### PR TITLE
remove lessons that are no longer in offline library

### DIFF
--- a/apps/local/lib/sync/runSync.ts
+++ b/apps/local/lib/sync/runSync.ts
@@ -483,6 +483,75 @@ export async function runSync({ syncRunId }: RunSyncOptions = {}) {
 
     const syncPayload = await fetchAssignedSyncData();
 
+    // Get all lesson IDs currently stored locally in SQLite
+    const existingLessons = db
+      .prepare<[], { id: number }>("SELECT id FROM lessons")
+      .all();
+
+    // Create a set of lesson IDs that SHOULD exist after sync (from Supabase)
+    const newLessonIds = new Set(syncPayload.lessons.map(l => l.id));
+
+    // Find lessons that exist locally but are NOT in the new sync payload
+    const lessonsToDelete = existingLessons.filter(
+      l => !newLessonIds.has(l.id),
+    );
+
+    const lessonIdsToDelete = lessonsToDelete.map(l => l.id);
+
+    const filesToDelete = db
+      .prepare<number[], { id: number; local_path: string | null }>(
+        `
+    SELECT f.id, f.local_path
+    FROM files f
+    JOIN lesson_files lf ON lf.file_id = f.id
+    WHERE lf.lesson_id IN (${lessonIdsToDelete.map(() => "?").join(",")})
+    `,
+      )
+      .all(...lessonIdsToDelete);
+
+    // Delete the actual file contents from disk
+    for (const file of filesToDelete) {
+      if (file.local_path && fs.existsSync(file.local_path)) {
+        console.log("[SYNC] Deleting file:", file.local_path);
+        fs.unlinkSync(file.local_path);
+      }
+    }
+
+    if (lessonIdsToDelete.length > 0) {
+      const placeholders = lessonIdsToDelete.map(() => "?").join(",");
+
+      // Get file IDs BEFORE deleting mappings
+      const fileIdsToDelete = db
+        .prepare<number[], { file_id: number }>(
+          `SELECT DISTINCT file_id FROM lesson_files WHERE lesson_id IN (${placeholders})`,
+        )
+        .all(...lessonIdsToDelete)
+        .map(r => r.file_id);
+
+      // Delete lesson-file mappings
+      db.prepare(
+        `DELETE FROM lesson_files WHERE lesson_id IN (${placeholders})`,
+      ).run(...lessonIdsToDelete);
+
+      // Break foreign key from files → lessons
+      db.prepare(
+        `UPDATE files SET lesson_id = NULL WHERE lesson_id IN (${placeholders})`,
+      ).run(...lessonIdsToDelete);
+
+      // Delete files using cached IDs
+      if (fileIdsToDelete.length > 0) {
+        const filePlaceholders = fileIdsToDelete.map(() => "?").join(",");
+        db.prepare(`DELETE FROM files WHERE id IN (${filePlaceholders})`).run(
+          ...fileIdsToDelete,
+        );
+      }
+
+      // Delete lessons
+      db.prepare(`DELETE FROM lessons WHERE id IN (${placeholders})`).run(
+        ...lessonIdsToDelete,
+      );
+    }
+
     await downloadFiles(
       syncPayload.files,
       syncPayload.lessons,


### PR DESCRIPTION
[//]: # "add the issue number from your sprint in the space below"
closes #154 

### description / changes made 
[//]: # "list (in bullet points) the main changes of this PR, especially if it's something that wasn't mentioned in the original issue."
- deletes existing files & lessons from local directory (pi) that aren't in the new sync 

### screenshots / demo vids
[//]: # "show evidence that your PR works -- especially important if this PR changed the UI."

https://github.com/user-attachments/assets/295cf9ea-faae-4ea9-a2e3-ab3c6c4cc328

### next steps
[//]: # "is there anything in this PR that does NOT work yet or needs to be refined later? are there any temporary fixes or files that need to be cleaned up later? did this PR involve any implementation decisions that will affect future PRs?"
- doesn't handle when a lesson is a part of more than one group (village)
- FILES DONT SHOW UP IN A LESSON SOMETIME!!!
- the sync library looks weird on safari

### notes
[//]: # "is there anything else that the reviewer of this PR should know? is there anything you'd like feedback on?"
- TEST TEST A LOTTTTTT, test on computer & on the pi

CC: @nathandtam
