### PR TITLE
make sync update statuses afterwards

### DIFF
--- a/apps/cloud/app/(authed)/app/lessons/LessonsClient.tsx
+++ b/apps/cloud/app/(authed)/app/lessons/LessonsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import supabase from "@/api/supabase/client";
 import ClassroomFilterDropdown from "@/components/ClassroomFilterDropdown";
 import CreateButton from "@/components/CreateLessonButton";
@@ -70,6 +71,8 @@ export default function LessonsClient({
   variant = "dashboard",
   showSortButton = false,
 }: LessonsClientProps) {
+  const router = useRouter();
+
   const [searchTerm, setSearchTerm] = useState("");
   const [view, setView] = useState<"grid" | "list">(defaultView);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -94,6 +97,7 @@ export default function LessonsClient({
     const saved = localStorage.getItem(
       "lessonsSortBy",
     ) as SortOptionValue | null;
+
     if (saved) {
       setSortBy(saved);
     }
@@ -194,25 +198,28 @@ export default function LessonsClient({
 
     if (listAction === "remove") {
       setRemoveConfirmLessonId(lessonId);
-      return;
     }
   }
 
   async function handleRestoreConfirm() {
     if (restoreConfirmLessonId === null) return;
 
-    setLoadingLessonId(restoreConfirmLessonId);
+    const lessonIdToRestore = restoreConfirmLessonId;
+
+    setLoadingLessonId(lessonIdToRestore);
 
     try {
       const { error } = await supabase
         .from("Lessons")
         .update({ is_archived: false })
-        .eq("id", restoreConfirmLessonId);
+        .eq("id", lessonIdToRestore);
 
       if (error) throw error;
 
-      setLessons(prev => prev.filter(l => l.id !== restoreConfirmLessonId));
+      setLessons(prev => prev.filter(l => l.id !== lessonIdToRestore));
       setRestoreConfirmLessonId(null);
+
+      router.refresh();
     } catch (err) {
       console.error(err);
     } finally {
@@ -222,24 +229,29 @@ export default function LessonsClient({
 
   async function handleRemoveConfirm() {
     if (removeConfirmLessonId === null) return;
+
     if (!deviceId) {
       console.error(new Error("Missing deviceId"));
       return;
     }
 
-    setLoadingLessonId(removeConfirmLessonId);
+    const lessonIdToRemove = removeConfirmLessonId;
+
+    setLoadingLessonId(lessonIdToRemove);
 
     try {
       const { error } = await supabase
         .from("DeviceLessons")
         .delete()
-        .eq("lesson_id", removeConfirmLessonId)
+        .eq("lesson_id", lessonIdToRemove)
         .eq("device_id", deviceId);
 
       if (error) throw error;
 
-      setLessons(prev => prev.filter(l => l.id !== removeConfirmLessonId));
+      setLessons(prev => prev.filter(l => l.id !== lessonIdToRemove));
       setRemoveConfirmLessonId(null);
+
+      router.refresh();
     } catch (err) {
       console.error(err);
     } finally {

--- a/apps/cloud/components/CloudSyncButton/index.tsx
+++ b/apps/cloud/components/CloudSyncButton/index.tsx
@@ -3,6 +3,7 @@
 import type { ModalVariant } from "@/components/SyncModal/styles";
 import type { SyncRunStatus, SyncStage } from "./syncStages";
 import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import supabase from "@/api/supabase/client";
 import SyncModal from "@/components/SyncModal";
 import { IconSvgs } from "@/lib/icons";
@@ -49,6 +50,8 @@ function formatLastSynced(lastSyncedAt: string | null) {
 }
 
 export default function CloudSyncButton({ userId }: { userId: string }) {
+  const router = useRouter();
+
   const [isSyncing, setIsSyncing] = useState(false);
   const [syncStage, setSyncStage] = useState<SyncStage | null>(null);
   const [device, setDevice] = useState<DeviceRow | null>(null);
@@ -153,6 +156,7 @@ export default function CloudSyncButton({ userId }: { userId: string }) {
       const completedRun = await waitForSyncRunCompletion(
         (data as { id: string }).id,
       );
+
       console.log("[CLOUD] Sync completed:", completedRun);
 
       await minLoadingTime;
@@ -164,6 +168,10 @@ export default function CloudSyncButton({ userId }: { userId: string }) {
         setLastSyncedAt(completedRun.completed_at ?? new Date().toISOString());
         setSyncStage(null);
         setModalVariant("success");
+
+        // Re-run the server page so SyncSummaryCard and LessonsClient receive
+        // fresh DeviceLessons data after the Pi updates lesson statuses.
+        router.refresh();
       } else {
         console.error("Sync failed:", completedRun.error_message);
         setSyncStage(null);

--- a/apps/cloud/components/StatusPill/index.tsx
+++ b/apps/cloud/components/StatusPill/index.tsx
@@ -5,7 +5,7 @@ export default function StatusPill({
 }: {
   status: "available" | "pending";
 }) {
-  const label = status === "available" ? "Available Offline" : "Pending Sync";
+  const label = status === "available" ? "Synced" : "Pending Sync";
 
   return (
     <Pill $status={status}>

--- a/apps/local/lib/sync/runSync.ts
+++ b/apps/local/lib/sync/runSync.ts
@@ -16,6 +16,7 @@ import {
   startLocalSyncRun,
 } from "@/lib/sync/sqliteStore";
 import { updateLastSyncedAt } from "@/lib/sync/updateLastSynced";
+import { updateDeviceLessonStatuses } from "@/lib/sync/updateLessonStatus";
 
 const BUCKET = "lesson-files";
 const LOCAL_DIR =
@@ -129,6 +130,7 @@ export async function runSync({ syncRunId }: RunSyncOptions = {}) {
 
     finishedAt = new Date().toISOString();
 
+    await updateDeviceLessonStatuses(DEVICE_ID, syncPayload.lessons);
     await updateLastSyncedAt(DEVICE_ID, finishedAt);
     await reportDeviceStorage(DEVICE_ID);
     finishLocalSyncRun(db, runId, finishedAt, "success");

--- a/apps/local/lib/sync/updateLessonStatus.ts
+++ b/apps/local/lib/sync/updateLessonStatus.ts
@@ -1,0 +1,28 @@
+import type { Lesson } from "@/lib/sync/types";
+import supabase from "@/api/supabase/client";
+
+// After a successful sync, every lesson assigned to this Pi is now available
+// locally, so the cloud assignment status can move from pending to available.
+export async function updateDeviceLessonStatuses(
+  deviceId: string,
+  lessons: Lesson[],
+) {
+  const lessonIds = lessons.map(lesson => lesson.id);
+
+  if (lessonIds.length === 0) {
+    return;
+  }
+
+  const { error } = await supabase
+    .from("DeviceLessons")
+    .update({
+      status: "available",
+    })
+    .eq("device_id", deviceId)
+    .in("lesson_id", lessonIds);
+
+  if (error) {
+    console.error("[SYNC] Failed to update DeviceLessons statuses:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
[//]: # "add the issue number from your sprint in the space below"
closes #259
closes #260

### description / changes made 
- syncing now updates lesson statuses to reflect available or pending sync
- changed tag text to be "synced" or "pending sync"
- refreshes sync page after a sync or when a lesson is removed
