### PR TITLE
add a +N indicator for classrooms

### DIFF
--- a/apps/cloud/components/LessonCard/index.tsx
+++ b/apps/cloud/components/LessonCard/index.tsx
@@ -8,6 +8,7 @@ import VillageTags from "../VillageTags";
 import {
   Card,
   ImageFrame,
+  MoreTag,
   StatusIconCircle,
   TagRow,
   Title,
@@ -44,6 +45,9 @@ export default function LessonCard({
 }) {
   const router = useRouter();
 
+  const visibleVillages = villages.slice(0, 2);
+  const remainingVillageCount = villages.length - visibleVillages.length;
+
   return (
     <Card onClick={() => router.push(`/app/lessons/${lessonId}`)}>
       <ImageFrame>
@@ -64,7 +68,10 @@ export default function LessonCard({
 
         {villages.length > 0 && (
           <TagRow>
-            <VillageTags villages={villages} />
+            <VillageTags villages={visibleVillages} />
+            {remainingVillageCount > 0 && (
+              <MoreTag>+{remainingVillageCount}</MoreTag>
+            )}
           </TagRow>
         )}
       </Titleholder>

--- a/apps/cloud/components/LessonCard/styles.ts
+++ b/apps/cloud/components/LessonCard/styles.ts
@@ -80,8 +80,31 @@ export const StatusIconCircle = styled.div<{
 export const TagRow = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   flex-wrap: nowrap;
   width: 100%;
   overflow: hidden;
+`;
+
+export const MoreTag = styled.span`
+  display: inline-flex;
+  width: fit-content;
+  min-height: 1.4375rem;
+  padding: 0.25rem 0.75rem;
+  box-sizing: border-box;
+
+  justify-content: center;
+  align-items: center;
+
+  flex-shrink: 0;
+
+  border-radius: 0.25rem;
+  background-color: ${COLORS.stem};
+
+  color: ${COLORS.gray100};
+  font-size: var(--font-subtitle-3);
+  line-height: var(--lh-subtitle-3);
+  font-weight: 400;
+
+  white-space: nowrap;
 `;

--- a/apps/cloud/components/VillageTags/styles.ts
+++ b/apps/cloud/components/VillageTags/styles.ts
@@ -17,6 +17,8 @@ export const VillageTag = styled.span<{
   justify-content: center;
   align-items: center;
 
+  flex-shrink: 0;
+
   border-radius: ${({ $variant }) =>
     $variant === "card" ? "0.25rem" : "1.25rem"};
   background-color: ${({ $variant }) =>
@@ -39,5 +41,6 @@ export const VillageTag = styled.span<{
 export const TagGroup = styled.div`
   display: flex;
   gap: 0.75rem;
+  flex-wrap: nowrap;
   overflow: hidden;
 `;


### PR DESCRIPTION
<img width="285" height="209" alt="Screenshot 2026-05-05 at 8 26 39 PM" src="https://github.com/user-attachments/assets/f9e5be3b-5471-4e0b-bcac-f7718f4fe8be" />

this makes it so that classroom tags do not squish within a card, but also do not get cut off (because u cant tell how many tags got cut off)