### PR TITLE
Fix files not showing up after sync

### DIFF
--- a/apps/local/api/sqlite/queries/query.ts
+++ b/apps/local/api/sqlite/queries/query.ts
@@ -1,34 +1,47 @@
 import { Group, Lesson, LocalFile } from "@/types/schema";
 
+export type LocalLessonFile = {
+  lesson_id: number;
+  file_id: number;
+};
+
 /**
  * Fetches the local SQLite database and returns its contents.
  * @returns An object containing the database's contents, with the following properties:
  *   - groups: An array of Group objects.
  *   - lessons: An array of Lesson objects.
  *   - files: An array of LocalFile objects.
+ *   - lessonFiles: An array of lesson-file relationship rows.
  */
 export async function fetchLocalDatabase(): Promise<{
   groups: Group[];
   lessons: Lesson[];
   files: LocalFile[];
+  lessonFiles: LocalLessonFile[];
 }> {
   try {
     const response = await fetch("/api/sqlite");
+
     if (!response.ok) {
       throw new Error("Failed to fetch data from local database");
     }
+
     const data = await response.json();
+
     return {
       groups: data.groups,
       lessons: data.lessons,
       files: data.files,
+      lessonFiles: data.lessonFiles ?? [],
     };
   } catch (error) {
     console.error("Error fetching data from local database:", error);
+
     return {
       groups: [],
       lessons: [],
       files: [],
+      lessonFiles: [],
     };
   }
 }

--- a/apps/local/app/api/sqlite/route.ts
+++ b/apps/local/app/api/sqlite/route.ts
@@ -4,6 +4,11 @@ import path from "path";
 import Database from "better-sqlite3";
 import { Group, Lesson, LocalFile } from "@/types/schema";
 
+type LocalLessonFile = {
+  lesson_id: number;
+  file_id: number;
+};
+
 export async function GET(): Promise<NextResponse> {
   try {
     const DB_PATH = path.join(process.cwd(), "rose-academies-uganda.db");
@@ -16,13 +21,19 @@ export async function GET(): Promise<NextResponse> {
     const groups = db.prepare("SELECT * FROM groups").all() as Group[];
     const lessons = db.prepare("SELECT * FROM lessons").all() as Lesson[];
     const files = db.prepare("SELECT * FROM files").all() as LocalFile[];
+    const lessonFiles = db
+      .prepare("SELECT lesson_id, file_id FROM lesson_files")
+      .all() as LocalLessonFile[];
 
     db.close();
 
-    return new NextResponse(JSON.stringify({ groups, lessons, files }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return new NextResponse(
+      JSON.stringify({ groups, lessons, files, lessonFiles }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   } catch (error) {
     console.error(error);
     return new NextResponse(JSON.stringify({ error: "Failed to fetch data" }), {

--- a/apps/local/app/lessons/[lessonId]/files/page.tsx
+++ b/apps/local/app/lessons/[lessonId]/files/page.tsx
@@ -17,6 +17,7 @@ import {
   HeaderRow,
   PageContainer,
   SearchBar as SearchBarWrapper,
+  TableWrapper,
   Title,
 } from "./style";
 
@@ -115,7 +116,9 @@ export default function FilesPage() {
       {tableFiles.length === 0 ? (
         <EmptyState>No files in this lesson yet.</EmptyState>
       ) : (
-        <FilesTable files={tableFiles} onRowClick={handleRowClick} />
+        <TableWrapper>
+          <FilesTable files={tableFiles} onRowClick={handleRowClick} />
+        </TableWrapper>
       )}
 
       {selectedFile && (

--- a/apps/local/app/lessons/[lessonId]/files/page.tsx
+++ b/apps/local/app/lessons/[lessonId]/files/page.tsx
@@ -44,7 +44,14 @@ export default function FilesPage() {
 
   const files = useMemo(() => {
     if (!data) return [];
-    return data.files.filter(file => file.lesson_id === lessonId);
+
+    const fileIdsForLesson = new Set(
+      data.lessonFiles
+        .filter(lessonFile => lessonFile.lesson_id === lessonId)
+        .map(lessonFile => lessonFile.file_id),
+    );
+
+    return data.files.filter(file => fileIdsForLesson.has(file.id));
   }, [data, lessonId]);
 
   const filteredFiles = useMemo(

--- a/apps/local/app/lessons/[lessonId]/files/style.ts
+++ b/apps/local/app/lessons/[lessonId]/files/style.ts
@@ -37,6 +37,12 @@ export const SearchBar = styled.div`
   width: 100%;
 `;
 
+export const TableWrapper = styled.div`
+  width: 100%;
+  margin-top: 23px;
+  flex: 0 0 auto;
+`;
+
 export const EmptyState = styled.div`
   margin-top: 23px;
 `;

--- a/apps/local/context/DataContext.tsx
+++ b/apps/local/context/DataContext.tsx
@@ -4,11 +4,24 @@ import { createContext, useEffect, useState } from "react";
 import { fetchLocalDatabase } from "@/api/sqlite/queries/query";
 import { Group, Lesson, LocalFile } from "@/types/schema";
 
+export type LocalLessonFile = {
+  lesson_id: number;
+  file_id: number;
+};
+
 interface DataContextType {
   groups: Group[];
   lessons: Lesson[];
   files: LocalFile[];
+  lessonFiles: LocalLessonFile[];
 }
+
+type LocalDatabaseResponse = {
+  groups: Group[];
+  lessons: Lesson[];
+  files: LocalFile[];
+  lessonFiles?: LocalLessonFile[];
+};
 
 export const DataContext = createContext<DataContextType | null>(null);
 
@@ -22,12 +35,19 @@ export function DataContextProvider({
   useEffect(() => {
     async function fetchData() {
       try {
-        const data = await fetchLocalDatabase();
-        setData(data);
+        const data = (await fetchLocalDatabase()) as LocalDatabaseResponse;
+
+        setData({
+          groups: data.groups,
+          lessons: data.lessons,
+          files: data.files,
+          lessonFiles: data.lessonFiles ?? [],
+        });
       } catch (error) {
         console.error("Error fetching local database:", error);
       }
     }
+
     fetchData();
   }, []);
 

--- a/apps/local/lib/sync/fileSync.ts
+++ b/apps/local/lib/sync/fileSync.ts
@@ -15,7 +15,9 @@ function storageUrlToKey(url: string, bucket: string): string {
   const idx = url.indexOf(marker);
 
   if (idx === -1) {
-    return url;
+    throw new Error(
+      `Could not extract storage object key. Expected bucket "${bucket}" in URL: ${url}`,
+    );
   }
 
   return url.slice(idx + marker.length);

--- a/apps/local/lib/sync/runSync.ts
+++ b/apps/local/lib/sync/runSync.ts
@@ -18,7 +18,7 @@ import {
 import { updateLastSyncedAt } from "@/lib/sync/updateLastSynced";
 import { updateDeviceLessonStatuses } from "@/lib/sync/updateLessonStatus";
 
-const BUCKET = "lesson-files";
+const BUCKET = "files";
 const LOCAL_DIR =
   process.env.LOCAL_FILES_DIR ?? path.join(os.homedir(), "rose-files");
 const DEVICE_ID = getDeviceId();


### PR DESCRIPTION
Fixed local sync file paths so downloaded files are saved using the correct Supabase storage object key.
Updated local SQLite data flow to include lesson_files relationships.
Updated the lesson files page to display files through the lesson_files join table instead of the old files.lesson_id field.
